### PR TITLE
Build and runtime fixes for OS X

### DIFF
--- a/sdl/src/video/quartz/SDL_QuartzVideo.h
+++ b/sdl/src/video/quartz/SDL_QuartzVideo.h
@@ -91,7 +91,11 @@ typedef struct SDL_PrivateVideoData {
     CGDirectDisplayID  display;            /* 0 == main display (only support single display) */
     const void         *mode;              /* current mode of the display */
     const void         *save_mode;         /* original mode of the display */
+
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 1070)
     CGDirectPaletteRef palette;            /* palette of an 8-bit display */
+#endif
+	
     NSOpenGLContext    *gl_context;        /* OpenGL rendering context */
     NSGraphicsContext  *nsgfx_context;     /* Cocoa graphics context */
     Uint32             width, height, bpp; /* frequently used data about the display */

--- a/sdl/src/video/quartz/SDL_QuartzVideo.m
+++ b/sdl/src/video/quartz/SDL_QuartzVideo.m
@@ -1635,7 +1635,7 @@ int QZ_GetGamma (_THIS, float *red, float *green, float *blue)
 
 int QZ_SetGammaRamp (_THIS, Uint16 *ramp)
 {
-    const uint32_t tableSize = 255;
+    const uint32_t tableSize = 256;
     CGGammaValue redTable[tableSize];
     CGGammaValue greenTable[tableSize];
     CGGammaValue blueTable[tableSize];


### PR DESCRIPTION
- Fixes a build issue when using the 10.9 SDK
- Fixes a critical memory-smasher in the video gamma-setting function.
