### PR TITLE
libs: fixed Lua io.popen support on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,7 @@ elseif(UNIX)
 		else()
 			add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/lua/src/liblua.a
 				COMMAND make clean || true
-				COMMAND make ${LUA_MAKE_TARGET} ${CROSS_COMPILE32_FLAGS}
+				COMMAND make ${LUA_MAKE_TARGET} CFLAGS=-mmacosx-version-min=10.7\ -O3\ -m32\ -DLUA_USE_MACOSX LDFLAGS=-mmacosx-version-min=10.7\ -m32
 				WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lua/src
 			)
 		endif()


### PR DESCRIPTION
The change feels quick'n'dirty, because I needed to copy the flags from the variable and add an additional one hardcoded. LUA compiles and popen works fine.

```
GeoIP is enabled. Database memory size: 1213.45 kb
[WolfAdmin] Module 1.2.0 (4 January 2019) loaded successfully. Created by Timo 'Timothy' Smit.
[WolfAdmin] WolfAdmin running in standalone mode on unix.
[WolfAdmin] commands.load(): 61 entries loaded in 61 ms
Game Initialization completed in 0.30 seconds.
```